### PR TITLE
ci: allow custom package path as action input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,9 +5,12 @@ author: 'flame-engine'
 branding:
   color: red
   icon: code
-
+inputs:
+  package-path:
+    description: 'The path where this action should be executed. If none is set, searches for packages inside the repo.'
+    required: false
 runs:
   using: 'composite'
   steps:
-    - run: ${{ github.action_path }}/scripts/dartdoc.sh
+    - run: ${{ github.action_path }}/scripts/dartdoc.sh ${{ inputs.package-path }}
       shell: bash

--- a/scripts/dartdoc.sh
+++ b/scripts/dartdoc.sh
@@ -13,7 +13,15 @@ function run_dartdoc() {
 
 echo "Starting Flame Dartdoc"
 echo "----------------------"
-for file in $(find ./packages -maxdepth 2 -type f -name "pubspec.yaml"); do
+
+# Prefer using packages from input
+PACKAGES=$1
+if [ -z $PACKAGES ]; then
+  # Searches for packages if none is set
+  PACKAGES=$(find ./packages -maxdepth 2 -type f -name "pubspec.yaml")
+fi
+
+for file in $PACKAGES; do
   dir=$(dirname $file)
   cd $dir
   echo "Generating dartdoc $dir"


### PR DESCRIPTION
## Description

- Make this action accept a custom package path input as a technical requirement to solve this issue: https://github.com/flame-engine/flame/issues/954
- With that, I was able to use the `matrix` strategy to run the `dartdoc` step for each Flame package in parallel.

To see that in action, give it a look at my Flame fork [here](https://github.com/mugbug/flame/actions/runs/1352167954)

I also tried to avoid breaking changes, so if no `package-path` is set, the action should have the previous behavior and look for packages inside the repo.

## Tradeoffs
- To achieve this, I needed to let the workflow that uses this action to know in which packages this action should be executed. This ends on making the Flame `cicd` workflow a little bit more complex and with more responsibilities.

## Example

<img width="978" alt="image" src="https://user-images.githubusercontent.com/19307199/137643837-722d4eaf-0e6f-4eff-b74e-8d4a385bd43c.png">
